### PR TITLE
Issue #1 Fixed: Display link to subscription's statements

### DIFF
--- a/app.css
+++ b/app.css
@@ -21,7 +21,7 @@ span.code {
     padding: 20%;
 }
 
-.center{
+.center {
 	text-align:center;
 }
 

--- a/templates/customerPage.hdbs
+++ b/templates/customerPage.hdbs
@@ -153,7 +153,12 @@
               <td colspan="2" class="center">
               	<a href="https://{{setting 'subdomain'}}.chargify.com/subscriptions/{{this.id}}/transactions/details" target="_blank">View Transactions</a>
               </td>
-            </tr>              
+            </tr>
+            <tr>
+              <td colspan="2" class="center">
+              	<a href="https://{{setting 'subdomain'}}.chargify.com/subscriptions/{{this.id}}/statements" target="_blank">View Statements</a>
+              </td>
+            </tr>
           </tbody>
         </table>
         {{/each}}


### PR DESCRIPTION
This PR displays a centered link "View Statements" below "View Transactions" (advice provided by @udayapitchika). I followed the Chargify Statements API documentation to get the proper link. 

PR closes #1.